### PR TITLE
Correct bug on serialization of UserTypes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -300,7 +300,7 @@ Improvements or Changes
 
 - Tests for Clients (External systems)
 
-- Add a `create_resource` method on the BaseTest to be able to create resources using the serializer
+- Add new parameter to `load_test_data` that indicates that we want to serialize the loaded JSON
 
 
 Bug Fixing

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -285,6 +285,8 @@ adds the following details to the response:
        -H "Content-Type: application/json" \
        -H "Authorization: Token ${CARAVAGGIO_TOKEN}"
 
+- Add `ListUserField` to the haystack fields to support list of UserDefinedTypes
+
 Improvements or Changes
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -300,6 +300,8 @@ Improvements or Changes
 
 - Tests for Clients (External systems)
 
+- Add a `create_resource` method on the BaseTest to be able to create resources using the serializer
+
 
 Bug Fixing
 **********

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -303,6 +303,7 @@ Bug Fixing
 **********
 
 - Fix bug when the results of a search query comes empty. We were accessing to some attributes that are not available when there is no results."
+- Fix bug to serialize UserTypes, the bug occurs when we try to serialize a list of UserTypes or when we have a UserType inside of another UserType.
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -285,7 +285,7 @@ adds the following details to the response:
        -H "Content-Type: application/json" \
        -H "Authorization: Token ${CARAVAGGIO_TOKEN}"
 
-- Add `ListUserField` to the haystack fields to support list of UserDefinedTypes
+- Add `CaravaggioListField` to the haystack fields to support list of UserDefinedTypes
 
 Improvements or Changes
 ***********************

--- a/src/caravaggio_rest_api/haystack/indexes.py
+++ b/src/caravaggio_rest_api/haystack/indexes.py
@@ -26,7 +26,7 @@ class BaseSearchIndex(indexes.SearchIndex):
         pass
 
 
-class ListUserField(indexes.MultiValueField):
+class CaravaggioListField(indexes.MultiValueField):
 
     def convert(self, value):
         value = super().convert(value)

--- a/src/caravaggio_rest_api/haystack/indexes.py
+++ b/src/caravaggio_rest_api/haystack/indexes.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*
 # Copyright (c) 2019 BuildGroup Data Services Inc.
 # All rights reserved.
+import json
+
 from haystack import indexes
 
 
@@ -22,3 +24,18 @@ class BaseSearchIndex(indexes.SearchIndex):
         #    obj.foundation_date, obj.stock_symbol
         # ))
         pass
+
+
+class ListUserField(indexes.MultiValueField):
+
+    def convert(self, value):
+        value = super().convert(value)
+
+        if not value:
+            return value
+
+        new_value = []
+        for _value in value:
+            new_value.append(json.loads(_value))
+
+        return new_value

--- a/src/caravaggio_rest_api/tests.py
+++ b/src/caravaggio_rest_api/tests.py
@@ -8,6 +8,7 @@ import logging
 from collections import OrderedDict
 from decimal import Decimal
 
+from caravaggio_rest_api.drf_haystack.serializers import deserialize_instance
 from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
 from rest_framework.authtoken.models import Token
@@ -78,7 +79,7 @@ class CaravaggioBaseTest(TestCase):
 
     @classmethod
     def load_test_data(cls, file, serializer_class=None,
-                       username=None, type="JSON"):
+                       username=None, type="JSON", return_pure_json=True):
 
         logging.info("Loading data from file {}".format(file))
 
@@ -96,6 +97,7 @@ class CaravaggioBaseTest(TestCase):
                              format(serializer_class))
                 has_errors = False
                 errors_by_resource = {}
+                object_json = []
                 for index, resource in enumerate(data):
                     serializer = serializer_class(
                         data=resource, context={'request': request})
@@ -104,12 +106,20 @@ class CaravaggioBaseTest(TestCase):
                         errors_by_resource["{}".format(index)] = \
                             serializer.errors
 
+                    if not return_pure_json:
+                        instance = deserialize_instance(serializer,
+                                                        serializer.Meta.model)
+                        object_json.append(instance)
+
                 if has_errors:
                     raise AssertionError(
                         "There are some errors in the json data of the test",
                         errors_by_resource)
+                elif not return_pure_json:
+                    return object_json
 
-            return data
+            if return_pure_json:
+                return data
         elif type == "CSV":
             data = []
             with open(file, 'r') as f:
@@ -129,19 +139,6 @@ class CaravaggioBaseTest(TestCase):
             "name": name
         }
         return CaravaggioClient.objects.create(**default_client)
-
-    def create_resource(self, resource, serializer_class, username=None):
-        if not username:
-            username = self.user.username
-
-        request = RequestFactory().get('./fake_path')
-        request.user = get_user_model().objects.get(username=username)
-
-        serializer = serializer_class(
-            data=resource, context={'request': request})
-
-        self.assertTrue(serializer.is_valid())
-        return serializer.create(resource)
 
     @classmethod
     def create_user(cls, email,

--- a/src/caravaggio_rest_api/tests.py
+++ b/src/caravaggio_rest_api/tests.py
@@ -130,6 +130,19 @@ class CaravaggioBaseTest(TestCase):
         }
         return CaravaggioClient.objects.create(**default_client)
 
+    def create_resource(self, resource, serializer_class, username=None):
+        if not username:
+            username = self.user.username
+
+        request = RequestFactory().get('./fake_path')
+        request.user = get_user_model().objects.get(username=username)
+
+        serializer = serializer_class(
+            data=resource, context={'request': request})
+
+        self.assertTrue(serializer.is_valid())
+        return serializer.create(resource)
+
     @classmethod
     def create_user(cls, email,
                     first_name=None, last_name=None, client=None,


### PR DESCRIPTION
**Changes**
* Add `CaravaggioListField` to the haystack fields to support list of UserDefinedTypes
* Add new parameter to `load_test_data` that indicates that we want to serialize the loaded JSON

**Bugs Fixed**
* Fix bug to serialize UserTypes, the bug occurs when we try to serialize a list of UserTypes or when we have a UserType inside of another UserType

**Tests**
* None
